### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-[![Add to Cursor](https://fastmcp.me/badges/cursor_dark.svg)](https://fastmcp.me/MCP/Details/1349/grokipedia)
-[![Add to VS Code](https://fastmcp.me/badges/vscode_dark.svg)](https://fastmcp.me/MCP/Details/1349/grokipedia)
-[![Add to Claude](https://fastmcp.me/badges/claude_dark.svg)](https://fastmcp.me/MCP/Details/1349/grokipedia)
-[![Add to ChatGPT](https://fastmcp.me/badges/chatgpt_dark.svg)](https://fastmcp.me/MCP/Details/1349/grokipedia)
-[![Add to Codex](https://fastmcp.me/badges/codex_dark.svg)](https://fastmcp.me/MCP/Details/1349/grokipedia)
-[![Add to Gemini](https://fastmcp.me/badges/gemini_dark.svg)](https://fastmcp.me/MCP/Details/1349/grokipedia)
-
 # Grokipedia MCP Server
 
 [![smithery badge](https://smithery.ai/badge/@skymoore/grokipedia-mcp)](https://smithery.ai/server/@skymoore/grokipedia-mcp)
 
 MCP server for searching and retrieving content from Grokipedia
+
+<a href="https://glama.ai/mcp/servers/@skymoore/grokipedia-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@skymoore/grokipedia-mcp/badge" alt="Grokipedia Server MCP server" />
+</a>
 
 The User of the MCP assumes full responsibility for interacting with [Grokipedia](https://grokipedia.com).
 


### PR DESCRIPTION
This PR adds a badge for the [Grokipedia MCP Server](https://glama.ai/mcp/servers/@skymoore/grokipedia-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@skymoore/grokipedia-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@skymoore/grokipedia-mcp/badge" alt="Grokipedia Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.